### PR TITLE
correct condition of L[0][0] = -1

### DIFF
--- a/inst/include/L2newick.h
+++ b/inst/include/L2newick.h
@@ -90,8 +90,8 @@ std::string ltable_to_newick(const std::vector< std::array< double, 4>>& ltable,
   if (std::abs(L[0][1]) < 0.0000001) {
     L[0][0] = -1.0;
   }
+  
   std::vector< std::string > linlist_4(L.size());
-
   size_t index = 0;
   for (const auto& i : L) {
     std::string add = "t" + std::to_string(abs(static_cast<int>(i[2])));

--- a/inst/include/L2newick.h
+++ b/inst/include/L2newick.h
@@ -82,13 +82,14 @@ std::string ltable_to_newick(const std::vector< std::array< double, 4>>& ltable,
     // keep a copy of the original ltable for later look up purpose
     L_original = L;
     L = new_L;
+    L_original[0][0] = -1.0;
   }
 
-  // L[0][0] cannot be -1 when extinct lineages are dropped
-  // but:
-  // L[1, 1] = -1
-  L[0][0] = -1.0;
-
+  // check whether L[1, ] is t1
+  // if yes, change L[1, 1] to -1
+  if (std::abs(L[0][1]) < 0.0000001) {
+    L[0][0] = -1.0;
+  }
   std::vector< std::string > linlist_4(L.size());
 
   size_t index = 0;
@@ -118,11 +119,19 @@ std::string ltable_to_newick(const std::vector< std::array< double, 4>>& ltable,
     } else {
       parentj = index_of_parent(L_original, parent);
       if(parentj == -1) {
+        std::string out_string;
+        for (auto &rows : L) {
+          for(auto &col : rows) {
+            out_string += std::to_string(col) + " ";
+          }
+          out_string += "\n";
+        }
         throw std::invalid_argument("Look up failed "+
                                      std::to_string(j) +
                                      " " +
                                      std::to_string(parent) +
-                                     " ");
+                                     "\n" +
+                                     out_string);
       }
       for (int i = 0; i <= 2; ++i) {
         L[j][i] = L_original[parentj][i];


### PR DESCRIPTION
Seems that the last issue is about L[1 ,1] = -1, the following code fixed ` l_to_phylo()`, I'll get `l_to_phylo_ed()` fixed too.
```c++
  if (drop_extinct == true) {
    // keep a copy of the original ltable for later look up purpose
    L_original = L;
    L = new_L;
    L_original[0][0] = -1.0;
  }

  // check whether L[1, ] is t1
  // if yes, change L[1, 1] to -1
  if (std::abs(L[0][1]) < 0.0000001) {
    L[0][0] = -1.0;
  }
```
Prove `treestats::l_to_phylo` equals `DDD::L2phylo`:

``` r
# get a random ltable
res <- DDD::dd_sim(c(0.5, 0.1, 20), 10)
# conversion by two functions
phy1 <- treestats::l_to_phylo(res$L, drop_extinct = T)
phy2 <- DDD::L2phylo(res$L, dropextinct = T)
# plot
par(mfrow = c(2, 1), mar = c(0, 0, 0, 0))
plot(phy1)
ape::edgelabels(round(phy1$edge.length, 2), col = "black", font = 2)
plot(phy2)
ape::edgelabels(round(phy2$edge.length, 2), col = "black", font = 2)
```

![](https://i.imgur.com/WYj9sw9.png)

``` r
# test whether L2phylo equals l_to_phylo
test_all_equal <- function(drop = FALSE) {
  res <- DDD::dd_sim(c(0.5, 0.1, 20), 10)
  phy1 <- treestats::l_to_phylo(res$L, drop_extinct = drop)
  phy2 <- DDD::L2phylo(res$L, dropextinct = drop)
  out <- all.equal(sum(phy1$edge.length),
                   sum(phy2$edge.length),
                   tolerance = 0.00001)
  return(out)
}

# test drop_extinct = F
out_list <- replicate(1000, test_all_equal(FALSE))
FALSE %in% out_list
#> [1] FALSE

# test drop_extinct = T
out_list2 <- replicate(1000, test_all_equal(TRUE))
FALSE %in% out_list2
#> [1] FALSE
```

<sup>Created on 2022-05-16 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>
