### PR TITLE
Reduce ultrametric test tolerance to 1e-7

### DIFF
--- a/R/util.R
+++ b/R/util.R
@@ -38,7 +38,7 @@ check_tree <- function(phy,
       }
     }
     if (require_ultrametric) {
-      valid <- ape::is.ultrametric(phy, tol = 0.01, option = 1)
+      valid <- ape::is.ultrametric(phy, tol = 1e-7, option = 1)
 
       if (!valid) {
         stop("Tree is not ultrametric, statistic not applicable")


### PR DESCRIPTION
As discussed in #25, reducing the ultrametric test tolerance may prevent most (but not all) crashes related to precision issues with the empirical tree branch lengths. Resolves #25 